### PR TITLE
Fix empty repo check for Mac OS X

### DIFF
--- a/bin/find_fattest_objects.sh
+++ b/bin/find_fattest_objects.sh
@@ -44,8 +44,8 @@ do
 done
 
 n_packs=$(ls .git/objects/pack/pack-*.idx 2> /dev/null | wc -l)
-[ "$n_packs" != "0"  ] || (echo "The repo is empty" && exit)
- 
+if [ $n_packs -eq 0 ]; then echo "The repo is empty" && exit 1; fi
+
 objects=`git verify-pack -v .git/objects/pack/pack-*.idx | grep -v objects | grep -v commit | sort -k4nr | head -n $NO_OF_FILES`
 
 output="raw_size(KB),compressed_size(KB),SHA,path,exists"


### PR DESCRIPTION
The code that checks if the repo is empty is not interpreted correctly by Mac OS X bash. $n_packs is left-padded with spaces so incorrectly passes the '== 0' check, and the construct '[test] || (do something then exit)' does not exit the script. 

OS X version 10.9 Mavericks
GNU bash, version 3.2.51(1)-release
