### PR TITLE
Allow to purge files with "unusual names"

### DIFF
--- a/bin/purge_objects.sh
+++ b/bin/purge_objects.sh
@@ -5,11 +5,11 @@ set -e
 paths=$@
 echo About to purge the following files: $paths
 
-git filter-branch --tag-name-filter cat --index-filter "git rm -rf --cached --ignore-unmatch $paths" -- --all
+git filter-branch --tag-name-filter cat --index-filter "git rm -rf --cached --ignore-unmatch -- $paths" -- --all
 
 git reset --hard 
 
-git for-each-ref --format="%(refname)" refs/original/ | xargs -n 1 git update-ref -d
+git for-each-ref --format="%(refname)" refs/original/ | xargs -n 1 git update-ref -d --
 
 git reflog expire --expire=now --all
 git gc --prune=now --aggressive


### PR DESCRIPTION
In some situations, (usually by accident) files with odd names
such as "-s" are added to the history.

These filenames are miss-interpreted by git as `command flags`
instead of filenames, which causes the crash of the purge sequence

By adding `--` prior to the filenames, git properly uses the argument
as a filename instead of a command flag, so these files may be
efectivelly purged.